### PR TITLE
Trigger search on keyup event on search textfield

### DIFF
--- a/app/assets/javascripts/app/controllers/sidebar.module.coffee
+++ b/app/assets/javascripts/app/controllers/sidebar.module.coffee
@@ -24,7 +24,7 @@ class Sidebar extends Controller
     @on('click', '.profile', @profile)
     @on('click', '.newPost', @newPost)
     @on('click', '.landing', @landing)
-    @on('search focus', 'input[type=search]', @search)
+    @on('keyup', 'input[type=search]', @search)
     $(window).on('keydown', @keydown)
 
     State.change 'sidebar', @setState


### PR DESCRIPTION
Firefox 32.0.3 will trigger the search event as the user edits the search text field as it does in Chrome.
Fixes #31
